### PR TITLE
LineLength as 160 characters instead of 100

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -34,7 +34,7 @@
 
     <module name="LineLength">
         <property name="fileExtensions" value="java"/>
-        <property name="max" value="100"/>
+        <property name="max" value="160"/>
         <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
     </module>
 


### PR DESCRIPTION
This rule is very important, but this limit is a little bit outdated, current screens allow wider lines!